### PR TITLE
fix a wrong type in wasm cursor icons

### DIFF
--- a/src/bevy_ext/cursor.rs
+++ b/src/bevy_ext/cursor.rs
@@ -152,7 +152,7 @@ impl LoadableCursor
             Self::Url { url, hotspot: _hotspot } => {
                 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
                 {
-                    Some(CursorIcon::Custom(CustomCursor::Url { url, hotspot: _hotspot }))
+                    Some(CursorIcon::Custom(CustomCursor::Url { url.to_string(), hotspot: _hotspot }))
                 }
 
                 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]

--- a/src/bevy_ext/cursor.rs
+++ b/src/bevy_ext/cursor.rs
@@ -152,7 +152,7 @@ impl LoadableCursor
             Self::Url { url, hotspot: _hotspot } => {
                 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
                 {
-                    Some(CursorIcon::Custom(CustomCursor::Url { url.to_string(), hotspot: _hotspot }))
+                    Some(CursorIcon::Custom(CustomCursor::Url { url: url.to_string(), hotspot: _hotspot }))
                 }
 
                 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]


### PR DESCRIPTION
It's expecting String, but getting a Cow<str>, currently preventing compilation to wasm