### PR TITLE
Fix PointerEnter method

### DIFF
--- a/src/sickle_ext/interaction_ext.rs
+++ b/src/sickle_ext/interaction_ext.rs
@@ -125,7 +125,7 @@ impl UiInteractionExt for UiBuilder<'_, Entity>
         callback: impl IntoSystem<(), R, M> + Send + Sync + 'static,
     ) -> &mut Self
     {
-        self.on_event::<Pressed>().r(callback);
+        self.on_event::<PointerEnter>().r(callback);
         self
     }
 


### PR DESCRIPTION
Seems it is using Pressed instead of PointerEnter. Workaround is to just use the on_event method instead