### PR TITLE
Basic grid support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ test = false
 name = "tests"
 path = "tests/test/mod.rs"
 doctest = false
-required-features = ["serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ test = false
 name = "tests"
 path = "tests/test/mod.rs"
 doctest = false
+required-features = ["serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/loading/cob/data/de/cob_builtin.rs
+++ b/src/loading/cob/data/de/cob_builtin.rs
@@ -1,5 +1,5 @@
 use bevy::color::Srgba;
-use bevy::ui::{GridTrack, Val};
+use bevy::ui::Val;
 use serde::de::{DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, Unexpected, VariantAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
@@ -21,13 +21,11 @@ where
 //-------------------------------------------------------------------------------------------------------------------
 
 // TODO: is there an easier way to do this by leveraging the Serialize implementation of Srgba?
-struct ColorSrgbaAccess
-{
+struct ColorSrgbaAccess {
     color: Srgba,
 }
 
-impl<'de> EnumAccess<'de> for ColorSrgbaAccess
-{
+impl<'de> EnumAccess<'de> for ColorSrgbaAccess {
     type Error = CobError;
     type Variant = ColorSrgbaVariantAccess;
 
@@ -43,17 +41,14 @@ impl<'de> EnumAccess<'de> for ColorSrgbaAccess
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct ColorSrgbaVariantAccess
-{
+struct ColorSrgbaVariantAccess {
     color: Srgba,
 }
 
-impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess
-{
+impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess {
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()>
-    {
+    fn unit_variant(self) -> CobResult<()> {
         Err(serde::de::Error::invalid_type(
             Unexpected::UnitVariant,
             &"newtype variant Srgba",
@@ -90,13 +85,11 @@ impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct SrgbaDeserializer
-{
+struct SrgbaDeserializer {
     color: Srgba,
 }
 
-impl<'de> serde::Deserializer<'de> for SrgbaDeserializer
-{
+impl<'de> serde::Deserializer<'de> for SrgbaDeserializer {
     type Error = CobError;
 
     fn deserialize_any<V>(self, visitor: V) -> CobResult<V::Value>
@@ -116,23 +109,19 @@ impl<'de> serde::Deserializer<'de> for SrgbaDeserializer
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct SrgbaAccess
-{
+struct SrgbaAccess {
     next: usize,
     color: Srgba,
     value: Option<f32>,
 }
 
-impl SrgbaAccess
-{
-    fn new(color: Srgba) -> Self
-    {
+impl SrgbaAccess {
+    fn new(color: Srgba) -> Self {
         SrgbaAccess { next: 0, color, value: None }
     }
 }
 
-impl<'de> MapAccess<'de> for SrgbaAccess
-{
+impl<'de> MapAccess<'de> for SrgbaAccess {
     type Error = CobError;
 
     fn next_key_seed<T>(&mut self, seed: T) -> CobResult<Option<T::Value>>
@@ -178,8 +167,7 @@ impl<'de> MapAccess<'de> for SrgbaAccess
         }
     }
 
-    fn size_hint(&self) -> Option<usize>
-    {
+    fn size_hint(&self) -> Option<usize> {
         Some(4usize.saturating_sub(self.next))
     }
 }
@@ -187,13 +175,11 @@ impl<'de> MapAccess<'de> for SrgbaAccess
 //-------------------------------------------------------------------------------------------------------------------
 
 // TODO: is there an easier way to do this by leveraging the Serialize implementation of Val?
-struct ValAccess
-{
+struct ValAccess {
     val: Val,
 }
 
-impl<'de> EnumAccess<'de> for ValAccess
-{
+impl<'de> EnumAccess<'de> for ValAccess {
     type Error = CobError;
     type Variant = ValVariantAccess;
 
@@ -218,17 +204,14 @@ impl<'de> EnumAccess<'de> for ValAccess
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct ValVariantAccess
-{
+struct ValVariantAccess {
     val: Val,
 }
 
-impl<'de> VariantAccess<'de> for ValVariantAccess
-{
+impl<'de> VariantAccess<'de> for ValVariantAccess {
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()>
-    {
+    fn unit_variant(self) -> CobResult<()> {
         match self.val {
             Val::Auto => Ok(()),
             _ => Err(serde::de::Error::invalid_type(
@@ -287,13 +270,11 @@ impl<'de> VariantAccess<'de> for ValVariantAccess
 }
 //-------------------------------------------------------------------------------------------------------------------
 
-struct GridValAccess
-{
+struct GridValAccess {
     val: GridVal,
 }
 
-impl<'de> EnumAccess<'de> for GridValAccess
-{
+impl<'de> EnumAccess<'de> for GridValAccess {
     type Error = CobError;
     type Variant = GridValVariantAccess;
 
@@ -301,7 +282,6 @@ impl<'de> EnumAccess<'de> for GridValAccess
     where
         V: DeserializeSeed<'de>,
     {
-        info!("enum access grid val access");
         let variant = match self.val {
             GridVal::Auto => "Auto",
             GridVal::Px(_) => "Px",
@@ -319,18 +299,14 @@ impl<'de> EnumAccess<'de> for GridValAccess
 }
 //-------------------------------------------------------------------------------------------------------------------
 
-struct GridValVariantAccess
-{
+struct GridValVariantAccess {
     val: GridVal,
 }
 
-impl<'de> VariantAccess<'de> for GridValVariantAccess
-{
+impl<'de> VariantAccess<'de> for GridValVariantAccess {
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()>
-    {
-        info!("unit");
+    fn unit_variant(self) -> CobResult<()> {
         match self.val {
             GridVal::Auto => Ok(()),
             _ => Err(serde::de::Error::invalid_type(
@@ -344,7 +320,6 @@ impl<'de> VariantAccess<'de> for GridValVariantAccess
     where
         T: DeserializeSeed<'de>,
     {
-        info!("newtype");
         match self.val {
             GridVal::Px(f)
             | GridVal::Percent(f)
@@ -364,7 +339,6 @@ impl<'de> VariantAccess<'de> for GridValVariantAccess
     where
         V: Visitor<'de>,
     {
-        info!("tuple");
         match self.val {
             GridVal::Auto => Err(serde::de::Error::invalid_type(
                 Unexpected::UnitVariant,
@@ -381,7 +355,6 @@ impl<'de> VariantAccess<'de> for GridValVariantAccess
     where
         V: Visitor<'de>,
     {
-        info!("struct");
         match self.val {
             GridVal::Auto => Err(serde::de::Error::invalid_type(
                 Unexpected::UnitVariant,

--- a/src/loading/cob/data/de/cob_builtin.rs
+++ b/src/loading/cob/data/de/cob_builtin.rs
@@ -1,5 +1,5 @@
 use bevy::color::Srgba;
-use bevy::ui::Val;
+use bevy::ui::{GridTrack, Val};
 use serde::de::{DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, Unexpected, VariantAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
@@ -14,6 +14,7 @@ where
     match builtin {
         CobBuiltin::Color(CobHexColor { color, .. }) => visitor.visit_enum(ColorSrgbaAccess { color: *color }),
         CobBuiltin::Val { val, .. } => visitor.visit_enum(ValAccess { val: *val }),
+        CobBuiltin::GridVal { val, .. } => visitor.visit_enum(GridValAccess { val: *val }),
     }
 }
 
@@ -284,5 +285,112 @@ impl<'de> VariantAccess<'de> for ValVariantAccess
         }
     }
 }
-
 //-------------------------------------------------------------------------------------------------------------------
+
+struct GridValAccess
+{
+    val: GridVal,
+}
+
+impl<'de> EnumAccess<'de> for GridValAccess
+{
+    type Error = CobError;
+    type Variant = GridValVariantAccess;
+
+    fn variant_seed<V>(self, seed: V) -> CobResult<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        info!("enum access grid val access");
+        let variant = match self.val {
+            GridVal::Auto => "Auto",
+            GridVal::Px(_) => "Px",
+            GridVal::Percent(_) => "Percent",
+            GridVal::Vw(_) => "Vw",
+            GridVal::Vh(_) => "Vh",
+            GridVal::VMin(_) => "VMin",
+            GridVal::VMax(_) => "VMax",
+            GridVal::Fr(_) => "Fr",
+        };
+        let variant = variant.into_deserializer();
+        let visitor = GridValVariantAccess { val: self.val };
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+
+struct GridValVariantAccess
+{
+    val: GridVal,
+}
+
+impl<'de> VariantAccess<'de> for GridValVariantAccess
+{
+    type Error = CobError;
+
+    fn unit_variant(self) -> CobResult<()>
+    {
+        info!("unit");
+        match self.val {
+            GridVal::Auto => Ok(()),
+            _ => Err(serde::de::Error::invalid_type(
+                Unexpected::NewtypeVariant,
+                &"unit variant",
+            )),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> CobResult<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        info!("newtype");
+        match self.val {
+            GridVal::Px(f)
+            | GridVal::Percent(f)
+            | GridVal::Vw(f)
+            | GridVal::Vh(f)
+            | GridVal::VMin(f)
+            | GridVal::VMax(f)
+            | GridVal::Fr(f) => seed.deserialize(f.into_deserializer()),
+            GridVal::Auto => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> CobResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        info!("tuple");
+        match self.val {
+            GridVal::Auto => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+            _ => Err(serde::de::Error::invalid_type(
+                Unexpected::NewtypeVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], _visitor: V) -> CobResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        info!("struct");
+        match self.val {
+            GridVal::Auto => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+            _ => Err(serde::de::Error::invalid_type(
+                Unexpected::NewtypeVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}

--- a/src/loading/cob/data/de/cob_builtin.rs
+++ b/src/loading/cob/data/de/cob_builtin.rs
@@ -21,11 +21,13 @@ where
 //-------------------------------------------------------------------------------------------------------------------
 
 // TODO: is there an easier way to do this by leveraging the Serialize implementation of Srgba?
-struct ColorSrgbaAccess {
+struct ColorSrgbaAccess
+{
     color: Srgba,
 }
 
-impl<'de> EnumAccess<'de> for ColorSrgbaAccess {
+impl<'de> EnumAccess<'de> for ColorSrgbaAccess
+{
     type Error = CobError;
     type Variant = ColorSrgbaVariantAccess;
 
@@ -41,14 +43,17 @@ impl<'de> EnumAccess<'de> for ColorSrgbaAccess {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct ColorSrgbaVariantAccess {
+struct ColorSrgbaVariantAccess
+{
     color: Srgba,
 }
 
-impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess {
+impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess
+{
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()> {
+    fn unit_variant(self) -> CobResult<()>
+    {
         Err(serde::de::Error::invalid_type(
             Unexpected::UnitVariant,
             &"newtype variant Srgba",
@@ -85,11 +90,13 @@ impl<'de> VariantAccess<'de> for ColorSrgbaVariantAccess {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct SrgbaDeserializer {
+struct SrgbaDeserializer
+{
     color: Srgba,
 }
 
-impl<'de> serde::Deserializer<'de> for SrgbaDeserializer {
+impl<'de> serde::Deserializer<'de> for SrgbaDeserializer
+{
     type Error = CobError;
 
     fn deserialize_any<V>(self, visitor: V) -> CobResult<V::Value>
@@ -109,19 +116,23 @@ impl<'de> serde::Deserializer<'de> for SrgbaDeserializer {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct SrgbaAccess {
+struct SrgbaAccess
+{
     next: usize,
     color: Srgba,
     value: Option<f32>,
 }
 
-impl SrgbaAccess {
-    fn new(color: Srgba) -> Self {
+impl SrgbaAccess
+{
+    fn new(color: Srgba) -> Self
+    {
         SrgbaAccess { next: 0, color, value: None }
     }
 }
 
-impl<'de> MapAccess<'de> for SrgbaAccess {
+impl<'de> MapAccess<'de> for SrgbaAccess
+{
     type Error = CobError;
 
     fn next_key_seed<T>(&mut self, seed: T) -> CobResult<Option<T::Value>>
@@ -167,7 +178,8 @@ impl<'de> MapAccess<'de> for SrgbaAccess {
         }
     }
 
-    fn size_hint(&self) -> Option<usize> {
+    fn size_hint(&self) -> Option<usize>
+    {
         Some(4usize.saturating_sub(self.next))
     }
 }
@@ -175,11 +187,13 @@ impl<'de> MapAccess<'de> for SrgbaAccess {
 //-------------------------------------------------------------------------------------------------------------------
 
 // TODO: is there an easier way to do this by leveraging the Serialize implementation of Val?
-struct ValAccess {
+struct ValAccess
+{
     val: Val,
 }
 
-impl<'de> EnumAccess<'de> for ValAccess {
+impl<'de> EnumAccess<'de> for ValAccess
+{
     type Error = CobError;
     type Variant = ValVariantAccess;
 
@@ -204,14 +218,17 @@ impl<'de> EnumAccess<'de> for ValAccess {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-struct ValVariantAccess {
+struct ValVariantAccess
+{
     val: Val,
 }
 
-impl<'de> VariantAccess<'de> for ValVariantAccess {
+impl<'de> VariantAccess<'de> for ValVariantAccess
+{
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()> {
+    fn unit_variant(self) -> CobResult<()>
+    {
         match self.val {
             Val::Auto => Ok(()),
             _ => Err(serde::de::Error::invalid_type(
@@ -270,11 +287,13 @@ impl<'de> VariantAccess<'de> for ValVariantAccess {
 }
 //-------------------------------------------------------------------------------------------------------------------
 
-struct GridValAccess {
+struct GridValAccess
+{
     val: GridVal,
 }
 
-impl<'de> EnumAccess<'de> for GridValAccess {
+impl<'de> EnumAccess<'de> for GridValAccess
+{
     type Error = CobError;
     type Variant = GridValVariantAccess;
 
@@ -299,14 +318,17 @@ impl<'de> EnumAccess<'de> for GridValAccess {
 }
 //-------------------------------------------------------------------------------------------------------------------
 
-struct GridValVariantAccess {
+struct GridValVariantAccess
+{
     val: GridVal,
 }
 
-impl<'de> VariantAccess<'de> for GridValVariantAccess {
+impl<'de> VariantAccess<'de> for GridValVariantAccess
+{
     type Error = CobError;
 
-    fn unit_variant(self) -> CobResult<()> {
+    fn unit_variant(self) -> CobResult<()>
+    {
         match self.val {
             GridVal::Auto => Ok(()),
             _ => Err(serde::de::Error::invalid_type(

--- a/src/loading/cob/data/value/cob_builtin.rs
+++ b/src/loading/cob/data/value/cob_builtin.rs
@@ -105,8 +105,11 @@ impl CobHexColor
 
         let len = start_len.saturating_sub(end_len);
         if len != 8 && len != 6 {
-            tracing::warn!("failed parsing hex color at {}; hex length is {} but expected 6 or 8",
-                get_location(content), len);
+            tracing::warn!(
+                "failed parsing hex color at {}; hex length is {} but expected 6 or 8",
+                get_location(content),
+                len
+            );
             return Err(span_verify_error(content));
         }
 
@@ -159,7 +162,8 @@ pub enum CobBuiltin
         number: Option<CobNumberValue>,
         val: Val,
     },
-    GridVal {
+    GridVal
+    {
         fill: CobFill,
         /// There is no number for `Val::Auto`.
         number: Option<CobNumberValue>,
@@ -167,12 +171,15 @@ pub enum CobBuiltin
     },
 }
 
-impl CobBuiltin {
-    pub fn write_to(&self, writer: &mut impl RawSerializer) -> Result<(), std::io::Error> {
+impl CobBuiltin
+{
+    pub fn write_to(&self, writer: &mut impl RawSerializer) -> Result<(), std::io::Error>
+    {
         self.write_to_with_space(writer, "")
     }
 
-    pub fn write_to_with_space(&self, writer: &mut impl RawSerializer, space: &str) -> Result<(), std::io::Error> {
+    pub fn write_to_with_space(&self, writer: &mut impl RawSerializer, space: &str) -> Result<(), std::io::Error>
+    {
         match self {
             Self::Color(color) => {
                 color.write_to_with_space(writer, space)?;
@@ -242,7 +249,8 @@ impl CobBuiltin {
         Ok(())
     }
 
-    pub fn try_parse(fill: CobFill, content: Span) -> Result<(Option<Self>, CobFill, Span), SpanError> {
+    pub fn try_parse(fill: CobFill, content: Span) -> Result<(Option<Self>, CobFill, Span), SpanError>
+    {
         // NOTE: recursion not tested here (not vulnerable)
 
         // Hex color
@@ -304,15 +312,15 @@ impl CobBuiltin {
         ))
     }
 
-    pub fn try_from_unit_variant(typename: &str, variant: &str) -> CobResult<Option<Self>> {
+    pub fn try_from_unit_variant(typename: &str, variant: &str) -> CobResult<Option<Self>>
+    {
         if typename == "Val" && variant == "Auto" {
             return Ok(Some(Self::Val {
                 fill: CobFill::default(),
                 number: None,
                 val: Val::Auto,
             }));
-        }
-        else if typename == "GridVal" && variant == "Auto"{
+        } else if typename == "GridVal" && variant == "Auto" {
             return Ok(Some(Self::GridVal {
                 fill: CobFill::default(),
                 number: None,
@@ -324,7 +332,8 @@ impl CobBuiltin {
     }
 
     /// The value should not contain any macros/constants.
-    pub fn try_from_newtype_variant(typename: &str, variant: &str, value: &CobValue) -> CobResult<Option<Self>> {
+    pub fn try_from_newtype_variant(typename: &str, variant: &str, value: &CobValue) -> CobResult<Option<Self>>
+    {
         if typename == "Color" && variant == "Srgba" {
             let CobValue::Map(CobMap { entries, .. }) = value else { return Ok(None) };
             let mut color = Srgba::default();
@@ -374,7 +383,7 @@ impl CobBuiltin {
                 val,
             }));
         }
-        if typename == "GridTrack" {
+        if typename == "GridVal" {
             let CobValue::Number(num) = value else { return Ok(None) };
             let Some(float) = num.number.as_f64() else { return Ok(None) };
             let extracted = float as f32;
@@ -386,6 +395,7 @@ impl CobBuiltin {
                 "Vh" => GridVal::Vh(extracted),
                 "VMin" => GridVal::VMin(extracted),
                 "VMax" => GridVal::VMax(extracted),
+                "Fr" => GridVal::Fr(extracted),
                 _ => return Err(CobError::MalformedBuiltin),
             };
 
@@ -399,7 +409,8 @@ impl CobBuiltin {
         Ok(None)
     }
 
-    pub fn recover_fill(&mut self, other: &Self) {
+    pub fn recover_fill(&mut self, other: &Self)
+    {
         match (self, other) {
             (Self::Color(color), Self::Color(other_color)) => {
                 color.recover_fill(other_color);

--- a/src/loading/cob/data/value/cob_builtin.rs
+++ b/src/loading/cob/data/value/cob_builtin.rs
@@ -265,10 +265,8 @@ impl CobBuiltin {
             match number.as_f32_lossy() {
                 Some(num) => Ok(num),
                 None => {
-                    tracing::warn!(
-                        "failed parsing builtin Val at {}; number failed to convert to f32",
-                        get_location(content).as_str()
-                    );
+                    tracing::warn!("failed parsing builtin Val at {}; number failed to convert to f32",
+                        get_location(content).as_str());
                     Err(span_verify_failure(content)) // non-recoverable error
                 }
             }

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -1030,7 +1030,7 @@ impl Instruction for FlexNode {
 ///
 /// Inserts a [`Node`] with [`Display::Grid`] and [`PositionType::Relative`].
 ///
-/// **NOTE** This does not support all Gridding features in bevy
+/// **NOTE**: This does not yet support all features of bevy's Grid layout.
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GridNode {

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -11,7 +11,8 @@ use crate::sickle::Lerp;
 /// All fields default to `Val::Px(0.)`.
 #[derive(Reflect, Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct StyleRect {
+pub struct StyleRect
+{
     #[reflect(default = "StyleRect::default_field")]
     pub top: Val,
     #[reflect(default = "StyleRect::default_field")]
@@ -22,19 +23,24 @@ pub struct StyleRect {
     pub right: Val,
 }
 
-impl StyleRect {
-    fn default_field() -> Val {
+impl StyleRect
+{
+    fn default_field() -> Val
+    {
         Val::Px(0.)
     }
 
     /// Constructs a style rect with all sides equal to `single`.
-    pub fn splat(single: Val) -> Self {
+    pub fn splat(single: Val) -> Self
+    {
         Self { top: single, bottom: single, left: single, right: single }
     }
 }
 
-impl Into<UiRect> for StyleRect {
-    fn into(self) -> UiRect {
+impl Into<UiRect> for StyleRect
+{
+    fn into(self) -> UiRect
+    {
         UiRect {
             left: self.left,
             right: self.right,
@@ -44,8 +50,10 @@ impl Into<UiRect> for StyleRect {
     }
 }
 
-impl From<UiRect> for StyleRect {
-    fn from(rect: UiRect) -> Self {
+impl From<UiRect> for StyleRect
+{
+    fn from(rect: UiRect) -> Self
+    {
         Self {
             left: rect.left,
             right: rect.right,
@@ -55,8 +63,10 @@ impl From<UiRect> for StyleRect {
     }
 }
 
-impl Default for StyleRect {
-    fn default() -> Self {
+impl Default for StyleRect
+{
+    fn default() -> Self
+    {
         Self {
             top: Self::default_field(),
             bottom: Self::default_field(),
@@ -66,8 +76,10 @@ impl Default for StyleRect {
     }
 }
 
-impl Lerp for StyleRect {
-    fn lerp(&self, to: Self, t: f32) -> Self {
+impl Lerp for StyleRect
+{
+    fn lerp(&self, to: Self, t: f32) -> Self
+    {
         Self {
             left: self.left.lerp(to.left, t),
             right: self.right.lerp(to.right, t),
@@ -86,7 +98,8 @@ impl Lerp for StyleRect {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum Clipping {
+pub enum Clipping
+{
     #[default]
     None,
     ClipX,
@@ -102,8 +115,10 @@ pub enum Clipping {
     ScrollXY,
 }
 
-impl Into<Overflow> for Clipping {
-    fn into(self) -> Overflow {
+impl Into<Overflow> for Clipping
+{
+    fn into(self) -> Overflow
+    {
         match self {
             Self::None => Overflow { x: OverflowAxis::Visible, y: OverflowAxis::Visible },
             Self::ClipX => Overflow { x: OverflowAxis::Clip, y: OverflowAxis::Visible },
@@ -136,7 +151,8 @@ impl Into<Overflow> for Clipping {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyLines {
+pub enum JustifyLines
+{
     /// Pack lines toward the start of the cross axis.
     ///
     /// Affected by `text_direction` (unimplemented) for [`FlexDirection::Column`].
@@ -166,8 +182,10 @@ pub enum JustifyLines {
     SpaceAround,
 }
 
-impl Into<AlignContent> for JustifyLines {
-    fn into(self) -> AlignContent {
+impl Into<AlignContent> for JustifyLines
+{
+    fn into(self) -> AlignContent
+    {
         match self {
             Self::FlexStart => AlignContent::FlexStart,
             Self::FlexEnd => AlignContent::FlexEnd,
@@ -203,7 +221,8 @@ impl Into<AlignContent> for JustifyLines {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyMain {
+pub enum JustifyMain
+{
     /*
     /// Cluster items at the start of the main axis.
     /// - [`FlexDirection::Row`]: Start according to `text_direction` (unimplemented).
@@ -245,8 +264,10 @@ pub enum JustifyMain {
     SpaceAround,
 }
 
-impl Into<JustifyContent> for JustifyMain {
-    fn into(self) -> JustifyContent {
+impl Into<JustifyContent> for JustifyMain
+{
+    fn into(self) -> JustifyContent
+    {
         match self {
             Self::FlexStart => JustifyContent::FlexStart,
             Self::FlexEnd => JustifyContent::FlexEnd,
@@ -277,7 +298,8 @@ impl Into<JustifyContent> for JustifyMain {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyCross {
+pub enum JustifyCross
+{
     /// Align children to the start of the cross axis in each line.
     #[default]
     FlexStart,
@@ -298,8 +320,10 @@ pub enum JustifyCross {
     Stretch,
 }
 
-impl Into<AlignItems> for JustifyCross {
-    fn into(self) -> AlignItems {
+impl Into<AlignItems> for JustifyCross
+{
+    fn into(self) -> AlignItems
+    {
         match self {
             Self::FlexStart => AlignItems::FlexStart,
             Self::FlexEnd => AlignItems::FlexEnd,
@@ -325,7 +349,8 @@ impl Into<AlignItems> for JustifyCross {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifySelfCross {
+pub enum JustifySelfCross
+{
     /// Adopt the parent's [`JustifyCross`] setting.
     #[default]
     Auto,
@@ -339,8 +364,10 @@ pub enum JustifySelfCross {
     Stretch,
 }
 
-impl Into<AlignSelf> for JustifySelfCross {
-    fn into(self) -> AlignSelf {
+impl Into<AlignSelf> for JustifySelfCross
+{
+    fn into(self) -> AlignSelf
+    {
         match self {
             Self::Auto => AlignSelf::Auto,
             Self::FlexStart => AlignSelf::FlexStart,
@@ -358,7 +385,8 @@ impl Into<AlignSelf> for JustifySelfCross {
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Dims {
+pub struct Dims
+{
     /// Indicates the `desired` width of the node.
     ///
     /// Defaults to [`Val::Auto`], which means 'content-sized'.
@@ -459,9 +487,11 @@ pub struct Dims {
     pub right: Val,
 }
 
-impl Dims {
+impl Dims
+{
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node) {
+    pub fn set_in_node(&self, node: &mut Node)
+    {
         node.width = self.width;
         node.height = self.height;
         node.max_width = self.max_width;
@@ -476,16 +506,20 @@ impl Dims {
         node.bottom = self.bottom;
     }
 
-    fn default_top() -> Val {
+    fn default_top() -> Val
+    {
         Val::Px(0.)
     }
-    fn default_left() -> Val {
+    fn default_left() -> Val
+    {
         Val::Px(0.)
     }
 }
 
-impl Default for Dims {
-    fn default() -> Self {
+impl Default for Dims
+{
+    fn default() -> Self
+    {
         Self {
             width: Default::default(),
             height: Default::default(),
@@ -510,7 +544,8 @@ impl Default for Dims {
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ContentFlex {
+pub struct ContentFlex
+{
     /// Determines whether the node contents will be clipped at the node boundary.
     ///
     /// Can be used to make a node scrollable.
@@ -592,9 +627,11 @@ pub struct ContentFlex {
     pub row_gap: Val,
 }
 
-impl ContentFlex {
+impl ContentFlex
+{
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node) {
+    pub fn set_in_node(&self, node: &mut Node)
+    {
         node.overflow = self.clipping.into();
         node.overflow_clip_margin = self.clip_margin;
         node.padding = self.padding.into();
@@ -607,13 +644,16 @@ impl ContentFlex {
         node.row_gap = self.row_gap;
     }
 
-    fn default_flex_wrap() -> FlexWrap {
+    fn default_flex_wrap() -> FlexWrap
+    {
         FlexWrap::NoWrap
     }
 }
 
-impl Default for ContentFlex {
-    fn default() -> Self {
+impl Default for ContentFlex
+{
+    fn default() -> Self
+    {
         Self {
             flex_wrap: Self::default_flex_wrap(),
 
@@ -637,7 +677,8 @@ impl Default for ContentFlex {
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SelfFlex {
+pub struct SelfFlex
+{
     /// Adds space outside the boundary of a node.
     ///
     /// If the main-axis values are set to [`Val::Auto`] then [`JustifyMain`] will do nothing, and similarly for
@@ -688,9 +729,11 @@ pub struct SelfFlex {
     pub justify_self_cross: JustifySelfCross,
 }
 
-impl SelfFlex {
+impl SelfFlex
+{
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node) {
+    pub fn set_in_node(&self, node: &mut Node)
+    {
         node.margin = self.margin.into();
         node.flex_basis = self.flex_basis;
         node.flex_grow = self.flex_grow;
@@ -699,8 +742,10 @@ impl SelfFlex {
     }
 }
 
-impl Default for SelfFlex {
-    fn default() -> Self {
+impl Default for SelfFlex
+{
+    fn default() -> Self
+    {
         Self {
             margin: Default::default(),
             flex_basis: Default::default(),
@@ -722,7 +767,8 @@ impl Default for SelfFlex {
 /// See [`FlexNode`] for flexbox-controlled nodes. See [`DisplayControl`] for setting [`Display::None`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AbsoluteNode {
+pub struct AbsoluteNode
+{
     // TODO: re-enable once #[reflect(flatten)] is available
     // #[reflect(default)]
     // pub dims: Dims,
@@ -800,8 +846,10 @@ pub struct AbsoluteNode {
     pub row_gap: Val,
 }
 
-impl Into<Node> for AbsoluteNode {
-    fn into(self) -> Node {
+impl Into<Node> for AbsoluteNode
+{
+    fn into(self) -> Node
+    {
         let mut node = Node::default();
         node.display = Display::Flex;
         node.position_type = PositionType::Absolute;
@@ -837,8 +885,10 @@ impl Into<Node> for AbsoluteNode {
     }
 }
 
-impl Instruction for AbsoluteNode {
-    fn apply(self, entity: Entity, world: &mut World) {
+impl Instruction for AbsoluteNode
+{
+    fn apply(self, entity: Entity, world: &mut World)
+    {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
 
         let display = emut.get::<DisplayControl>().copied().unwrap_or_default();
@@ -848,7 +898,8 @@ impl Instruction for AbsoluteNode {
         emut.insert(node);
     }
 
-    fn revert(entity: Entity, world: &mut World) {
+    fn revert(entity: Entity, world: &mut World)
+    {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove_with_requires::<Node>();
         });
@@ -864,7 +915,8 @@ impl Instruction for AbsoluteNode {
 /// See [`AbsoluteNode`] for absolute-positioned nodes. See [`DisplayControl`] for setting [`Display::None`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct FlexNode {
+pub struct FlexNode
+{
     // TODO: re-enable once #[reflect(flatten)] is available
     // #[reflect(default)]
     // pub dims: Dims,
@@ -961,8 +1013,10 @@ pub struct FlexNode {
     pub justify_self_cross: JustifySelfCross,
 }
 
-impl Into<Node> for FlexNode {
-    fn into(self) -> Node {
+impl Into<Node> for FlexNode
+{
+    fn into(self) -> Node
+    {
         let mut node = Node::default();
         node.display = Display::Flex;
         node.position_type = PositionType::Relative;
@@ -1006,8 +1060,10 @@ impl Into<Node> for FlexNode {
     }
 }
 
-impl Instruction for FlexNode {
-    fn apply(self, entity: Entity, world: &mut World) {
+impl Instruction for FlexNode
+{
+    fn apply(self, entity: Entity, world: &mut World)
+    {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
 
         let display = emut.get::<DisplayControl>().copied().unwrap_or_default();
@@ -1017,7 +1073,8 @@ impl Instruction for FlexNode {
         emut.insert(node);
     }
 
-    fn revert(entity: Entity, world: &mut World) {
+    fn revert(entity: Entity, world: &mut World)
+    {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove_with_requires::<Node>();
         });
@@ -1033,7 +1090,8 @@ impl Instruction for FlexNode {
 /// **NOTE**: This does not yet support all features of bevy's Grid layout.
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GridNode {
+pub struct GridNode
+{
     // DIMS
     /// See [`Dims::width`].
     #[reflect(default)]
@@ -1121,8 +1179,10 @@ pub struct GridNode {
     pub row_gap: Val,
 }
 
-impl Instruction for GridNode {
-    fn apply(self, entity: Entity, world: &mut World) {
+impl Instruction for GridNode
+{
+    fn apply(self, entity: Entity, world: &mut World)
+    {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
 
         // let display = emut.get::<DisplayControl>().copied().unwrap_or_default();
@@ -1132,15 +1192,18 @@ impl Instruction for GridNode {
         emut.insert(node);
     }
 
-    fn revert(entity: Entity, world: &mut World) {
+    fn revert(entity: Entity, world: &mut World)
+    {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove_with_requires::<Node>();
         });
     }
 }
 
-impl Into<Node> for GridNode {
-    fn into(self) -> Node {
+impl Into<Node> for GridNode
+{
+    fn into(self) -> Node
+    {
         let mut node = Node::default();
         node.display = Display::Grid;
         node.position_type = PositionType::Relative;
@@ -1200,18 +1263,19 @@ impl Into<Node> for GridNode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum DisplayControl {
+pub enum DisplayControl
+{
     /// Corresponds to [`Display::Flex`].
     #[default]
     Flex,
-    ///There for grid based displays
-    Grid,
     /// Corresponds to [`Display::None`].
     Hide,
 }
 
-impl DisplayControl {
-    fn refresh(mut nodes: Query<(&mut Node, &DisplayControl), Or<(Changed<Node>, Changed<DisplayControl>)>>) {
+impl DisplayControl
+{
+    fn refresh(mut nodes: Query<(&mut Node, &DisplayControl), Or<(Changed<Node>, Changed<DisplayControl>)>>)
+    {
         for (mut node, control) in nodes.iter_mut() {
             if node.display != (*control).into() {
                 node.display = (*control).into();
@@ -1220,23 +1284,27 @@ impl DisplayControl {
     }
 }
 
-impl Into<Display> for DisplayControl {
-    fn into(self) -> Display {
+impl Into<Display> for DisplayControl
+{
+    fn into(self) -> Display
+    {
         match self {
             Self::Flex => Display::Flex,
             Self::Hide => Display::None,
-            Self::Grid => Display::Grid,
         }
     }
 }
 
-impl Instruction for DisplayControl {
-    fn apply(self, entity: Entity, world: &mut World) {
+impl Instruction for DisplayControl
+{
+    fn apply(self, entity: Entity, world: &mut World)
+    {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
         emut.insert(self);
     }
 
-    fn revert(entity: Entity, world: &mut World) {
+    fn revert(entity: Entity, world: &mut World)
+    {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove::<Self>();
             if let Some(mut node) = e.get_mut::<Node>() {
@@ -1246,9 +1314,11 @@ impl Instruction for DisplayControl {
     }
 }
 
-impl StaticAttribute for DisplayControl {
+impl StaticAttribute for DisplayControl
+{
     type Value = Self;
-    fn construct(value: Self::Value) -> Self {
+    fn construct(value: Self::Value) -> Self
+    {
         value
     }
 }
@@ -1265,7 +1335,8 @@ impl StaticAttribute for DisplayControl {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum GridVal {
+pub enum GridVal
+{
     #[default]
     Auto,
     Percent(f32),
@@ -1277,8 +1348,10 @@ pub enum GridVal {
     Fr(f32),
 }
 
-impl From<GridVal> for GridTrack {
-    fn from(value: GridVal) -> Self {
+impl From<GridVal> for GridTrack
+{
+    fn from(value: GridVal) -> Self
+    {
         match value {
             GridVal::Auto => GridTrack::auto(),
             GridVal::Percent(f) => GridTrack::percent(f),
@@ -1296,8 +1369,10 @@ impl From<GridVal> for GridTrack {
 
 pub(crate) struct StyleWrappersPlugin;
 
-impl Plugin for StyleWrappersPlugin {
-    fn build(&self, app: &mut App) {
+impl Plugin for StyleWrappersPlugin
+{
+    fn build(&self, app: &mut App)
+    {
         app.register_instruction_type::<AbsoluteNode>()
             .register_instruction_type::<FlexNode>()
             .register_instruction_type::<GridNode>()

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -1257,7 +1257,7 @@ impl StaticAttribute for DisplayControl {
 #[derive(Clone, Copy, Default, Debug, Reflect, PartialEq)]
 #[reflect(Default, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serialize",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -11,8 +11,7 @@ use crate::sickle::Lerp;
 /// All fields default to `Val::Px(0.)`.
 #[derive(Reflect, Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct StyleRect
-{
+pub struct StyleRect {
     #[reflect(default = "StyleRect::default_field")]
     pub top: Val,
     #[reflect(default = "StyleRect::default_field")]
@@ -23,24 +22,19 @@ pub struct StyleRect
     pub right: Val,
 }
 
-impl StyleRect
-{
-    fn default_field() -> Val
-    {
+impl StyleRect {
+    fn default_field() -> Val {
         Val::Px(0.)
     }
 
     /// Constructs a style rect with all sides equal to `single`.
-    pub fn splat(single: Val) -> Self
-    {
+    pub fn splat(single: Val) -> Self {
         Self { top: single, bottom: single, left: single, right: single }
     }
 }
 
-impl Into<UiRect> for StyleRect
-{
-    fn into(self) -> UiRect
-    {
+impl Into<UiRect> for StyleRect {
+    fn into(self) -> UiRect {
         UiRect {
             left: self.left,
             right: self.right,
@@ -50,10 +44,8 @@ impl Into<UiRect> for StyleRect
     }
 }
 
-impl From<UiRect> for StyleRect
-{
-    fn from(rect: UiRect) -> Self
-    {
+impl From<UiRect> for StyleRect {
+    fn from(rect: UiRect) -> Self {
         Self {
             left: rect.left,
             right: rect.right,
@@ -63,10 +55,8 @@ impl From<UiRect> for StyleRect
     }
 }
 
-impl Default for StyleRect
-{
-    fn default() -> Self
-    {
+impl Default for StyleRect {
+    fn default() -> Self {
         Self {
             top: Self::default_field(),
             bottom: Self::default_field(),
@@ -76,10 +66,8 @@ impl Default for StyleRect
     }
 }
 
-impl Lerp for StyleRect
-{
-    fn lerp(&self, to: Self, t: f32) -> Self
-    {
+impl Lerp for StyleRect {
+    fn lerp(&self, to: Self, t: f32) -> Self {
         Self {
             left: self.left.lerp(to.left, t),
             right: self.right.lerp(to.right, t),
@@ -98,8 +86,7 @@ impl Lerp for StyleRect
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum Clipping
-{
+pub enum Clipping {
     #[default]
     None,
     ClipX,
@@ -115,10 +102,8 @@ pub enum Clipping
     ScrollXY,
 }
 
-impl Into<Overflow> for Clipping
-{
-    fn into(self) -> Overflow
-    {
+impl Into<Overflow> for Clipping {
+    fn into(self) -> Overflow {
         match self {
             Self::None => Overflow { x: OverflowAxis::Visible, y: OverflowAxis::Visible },
             Self::ClipX => Overflow { x: OverflowAxis::Clip, y: OverflowAxis::Visible },
@@ -151,8 +136,7 @@ impl Into<Overflow> for Clipping
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyLines
-{
+pub enum JustifyLines {
     /// Pack lines toward the start of the cross axis.
     ///
     /// Affected by `text_direction` (unimplemented) for [`FlexDirection::Column`].
@@ -182,10 +166,8 @@ pub enum JustifyLines
     SpaceAround,
 }
 
-impl Into<AlignContent> for JustifyLines
-{
-    fn into(self) -> AlignContent
-    {
+impl Into<AlignContent> for JustifyLines {
+    fn into(self) -> AlignContent {
         match self {
             Self::FlexStart => AlignContent::FlexStart,
             Self::FlexEnd => AlignContent::FlexEnd,
@@ -221,8 +203,7 @@ impl Into<AlignContent> for JustifyLines
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyMain
-{
+pub enum JustifyMain {
     /*
     /// Cluster items at the start of the main axis.
     /// - [`FlexDirection::Row`]: Start according to `text_direction` (unimplemented).
@@ -264,10 +245,8 @@ pub enum JustifyMain
     SpaceAround,
 }
 
-impl Into<JustifyContent> for JustifyMain
-{
-    fn into(self) -> JustifyContent
-    {
+impl Into<JustifyContent> for JustifyMain {
+    fn into(self) -> JustifyContent {
         match self {
             Self::FlexStart => JustifyContent::FlexStart,
             Self::FlexEnd => JustifyContent::FlexEnd,
@@ -298,8 +277,7 @@ impl Into<JustifyContent> for JustifyMain
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifyCross
-{
+pub enum JustifyCross {
     /// Align children to the start of the cross axis in each line.
     #[default]
     FlexStart,
@@ -320,10 +298,8 @@ pub enum JustifyCross
     Stretch,
 }
 
-impl Into<AlignItems> for JustifyCross
-{
-    fn into(self) -> AlignItems
-    {
+impl Into<AlignItems> for JustifyCross {
+    fn into(self) -> AlignItems {
         match self {
             Self::FlexStart => AlignItems::FlexStart,
             Self::FlexEnd => AlignItems::FlexEnd,
@@ -349,8 +325,7 @@ impl Into<AlignItems> for JustifyCross
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum JustifySelfCross
-{
+pub enum JustifySelfCross {
     /// Adopt the parent's [`JustifyCross`] setting.
     #[default]
     Auto,
@@ -364,10 +339,8 @@ pub enum JustifySelfCross
     Stretch,
 }
 
-impl Into<AlignSelf> for JustifySelfCross
-{
-    fn into(self) -> AlignSelf
-    {
+impl Into<AlignSelf> for JustifySelfCross {
+    fn into(self) -> AlignSelf {
         match self {
             Self::Auto => AlignSelf::Auto,
             Self::FlexStart => AlignSelf::FlexStart,
@@ -385,8 +358,7 @@ impl Into<AlignSelf> for JustifySelfCross
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Dims
-{
+pub struct Dims {
     /// Indicates the `desired` width of the node.
     ///
     /// Defaults to [`Val::Auto`], which means 'content-sized'.
@@ -487,11 +459,9 @@ pub struct Dims
     pub right: Val,
 }
 
-impl Dims
-{
+impl Dims {
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node)
-    {
+    pub fn set_in_node(&self, node: &mut Node) {
         node.width = self.width;
         node.height = self.height;
         node.max_width = self.max_width;
@@ -506,20 +476,16 @@ impl Dims
         node.bottom = self.bottom;
     }
 
-    fn default_top() -> Val
-    {
+    fn default_top() -> Val {
         Val::Px(0.)
     }
-    fn default_left() -> Val
-    {
+    fn default_left() -> Val {
         Val::Px(0.)
     }
 }
 
-impl Default for Dims
-{
-    fn default() -> Self
-    {
+impl Default for Dims {
+    fn default() -> Self {
         Self {
             width: Default::default(),
             height: Default::default(),
@@ -544,8 +510,7 @@ impl Default for Dims
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ContentFlex
-{
+pub struct ContentFlex {
     /// Determines whether the node contents will be clipped at the node boundary.
     ///
     /// Can be used to make a node scrollable.
@@ -627,11 +592,9 @@ pub struct ContentFlex
     pub row_gap: Val,
 }
 
-impl ContentFlex
-{
+impl ContentFlex {
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node)
-    {
+    pub fn set_in_node(&self, node: &mut Node) {
         node.overflow = self.clipping.into();
         node.overflow_clip_margin = self.clip_margin;
         node.padding = self.padding.into();
@@ -644,16 +607,13 @@ impl ContentFlex
         node.row_gap = self.row_gap;
     }
 
-    fn default_flex_wrap() -> FlexWrap
-    {
+    fn default_flex_wrap() -> FlexWrap {
         FlexWrap::NoWrap
     }
 }
 
-impl Default for ContentFlex
-{
-    fn default() -> Self
-    {
+impl Default for ContentFlex {
+    fn default() -> Self {
         Self {
             flex_wrap: Self::default_flex_wrap(),
 
@@ -677,8 +637,7 @@ impl Default for ContentFlex
 /// Mirrors fields in [`Node`].
 #[derive(Reflect, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SelfFlex
-{
+pub struct SelfFlex {
     /// Adds space outside the boundary of a node.
     ///
     /// If the main-axis values are set to [`Val::Auto`] then [`JustifyMain`] will do nothing, and similarly for
@@ -729,11 +688,9 @@ pub struct SelfFlex
     pub justify_self_cross: JustifySelfCross,
 }
 
-impl SelfFlex
-{
+impl SelfFlex {
     /// Adds this struct's contents to [`Node`].
-    pub fn set_in_node(&self, node: &mut Node)
-    {
+    pub fn set_in_node(&self, node: &mut Node) {
         node.margin = self.margin.into();
         node.flex_basis = self.flex_basis;
         node.flex_grow = self.flex_grow;
@@ -742,10 +699,8 @@ impl SelfFlex
     }
 }
 
-impl Default for SelfFlex
-{
-    fn default() -> Self
-    {
+impl Default for SelfFlex {
+    fn default() -> Self {
         Self {
             margin: Default::default(),
             flex_basis: Default::default(),
@@ -767,8 +722,7 @@ impl Default for SelfFlex
 /// See [`FlexNode`] for flexbox-controlled nodes. See [`DisplayControl`] for setting [`Display::None`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AbsoluteNode
-{
+pub struct AbsoluteNode {
     // TODO: re-enable once #[reflect(flatten)] is available
     // #[reflect(default)]
     // pub dims: Dims,
@@ -846,10 +800,8 @@ pub struct AbsoluteNode
     pub row_gap: Val,
 }
 
-impl Into<Node> for AbsoluteNode
-{
-    fn into(self) -> Node
-    {
+impl Into<Node> for AbsoluteNode {
+    fn into(self) -> Node {
         let mut node = Node::default();
         node.display = Display::Flex;
         node.position_type = PositionType::Absolute;
@@ -885,10 +837,8 @@ impl Into<Node> for AbsoluteNode
     }
 }
 
-impl Instruction for AbsoluteNode
-{
-    fn apply(self, entity: Entity, world: &mut World)
-    {
+impl Instruction for AbsoluteNode {
+    fn apply(self, entity: Entity, world: &mut World) {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
 
         let display = emut.get::<DisplayControl>().copied().unwrap_or_default();
@@ -898,8 +848,7 @@ impl Instruction for AbsoluteNode
         emut.insert(node);
     }
 
-    fn revert(entity: Entity, world: &mut World)
-    {
+    fn revert(entity: Entity, world: &mut World) {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove_with_requires::<Node>();
         });
@@ -915,8 +864,7 @@ impl Instruction for AbsoluteNode
 /// See [`AbsoluteNode`] for absolute-positioned nodes. See [`DisplayControl`] for setting [`Display::None`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct FlexNode
-{
+pub struct FlexNode {
     // TODO: re-enable once #[reflect(flatten)] is available
     // #[reflect(default)]
     // pub dims: Dims,
@@ -1013,10 +961,8 @@ pub struct FlexNode
     pub justify_self_cross: JustifySelfCross,
 }
 
-impl Into<Node> for FlexNode
-{
-    fn into(self) -> Node
-    {
+impl Into<Node> for FlexNode {
+    fn into(self) -> Node {
         let mut node = Node::default();
         node.display = Display::Flex;
         node.position_type = PositionType::Relative;
@@ -1060,10 +1006,8 @@ impl Into<Node> for FlexNode
     }
 }
 
-impl Instruction for FlexNode
-{
-    fn apply(self, entity: Entity, world: &mut World)
-    {
+impl Instruction for FlexNode {
+    fn apply(self, entity: Entity, world: &mut World) {
         let Ok(mut emut) = world.get_entity_mut(entity) else { return };
 
         let display = emut.get::<DisplayControl>().copied().unwrap_or_default();
@@ -1073,8 +1017,7 @@ impl Instruction for FlexNode
         emut.insert(node);
     }
 
-    fn revert(entity: Entity, world: &mut World)
-    {
+    fn revert(entity: Entity, world: &mut World) {
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove_with_requires::<Node>();
         });

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -1072,15 +1072,19 @@ pub struct GridNode {
     #[reflect(default)]
     pub right: Val,
 
-    /// Grid based formating
-    /// Put valuse inside `[]` brackets
-    /// **Note** only GridVal variants are supported, which is not all Bevy supported gridding
+    /// Grid layout
+    /// 
+    /// Put values inside `[]` brackets.
+    /// 
+    /// **Note**: Only [`GridVal`] variants are supported, which only has a subset of the `GridTrack` API.
     #[reflect(default)]
     pub grid_template_rows: Vec<GridVal>,
 
-    /// Grid based formating
-    /// Put valuse inside `[]` brackets
-    /// **Note** only GridVal variants are supported, which is not all Bevy supported gridding
+    /// Grid layout
+    /// 
+    /// Put values inside `[]` brackets.
+    /// 
+    /// **Note**: Only [`GridVal`] variants are supported, which only has a subset of the `GridTrack` API.
     #[reflect(default)]
     pub grid_template_columns: Vec<GridVal>,
 
@@ -1251,9 +1255,9 @@ impl StaticAttribute for DisplayControl {
 
 //-------------------------------------------------------------------------------------------------------------------
 
-/// Like Val but also accepts additional values for grid based layouts
-/// Derived traits are based on Val's derived traits
-/// After the data is serialised it should be converted to GridTrack
+/// Like [`Val`] but also accepts additional values for grid layouts.
+///
+/// Can be converted to a [`GridTrack`] for use in [`Node`].
 #[derive(Clone, Copy, Default, Debug, Reflect, PartialEq)]
 #[reflect(Default, PartialEq, Debug)]
 #[cfg_attr(

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -1131,17 +1131,17 @@ pub struct GridNode
     pub right: Val,
 
     /// Grid layout
-    /// 
+    ///
     /// Put values inside `[]` brackets.
-    /// 
+    ///
     /// **Note**: Only [`GridVal`] variants are supported, which only has a subset of the `GridTrack` API.
     #[reflect(default)]
     pub grid_template_rows: Vec<GridVal>,
 
     /// Grid layout
-    /// 
+    ///
     /// Put values inside `[]` brackets.
-    /// 
+    ///
     /// **Note**: Only [`GridVal`] variants are supported, which only has a subset of the `GridTrack` API.
     #[reflect(default)]
     pub grid_template_columns: Vec<GridVal>,
@@ -1267,7 +1267,7 @@ pub enum DisplayControl
 {
     /// Corresponds to [`Display::Flex`].
     #[default]
-    Flex,
+    Show,
     /// Corresponds to [`Display::None`].
     Hide,
 }
@@ -1289,7 +1289,7 @@ impl Into<Display> for DisplayControl
     fn into(self) -> Display
     {
         match self {
-            Self::Flex => Display::Flex,
+            Self::Show => Display::Flex,
             Self::Hide => Display::None,
         }
     }
@@ -1308,7 +1308,7 @@ impl Instruction for DisplayControl
         let _ = world.get_entity_mut(entity).map(|mut e| {
             e.remove::<Self>();
             if let Some(mut node) = e.get_mut::<Node>() {
-                node.display = Self::Flex.into();
+                node.display = Self::Show.into();
             }
         });
     }

--- a/src/ui_bevy/ui_ext/style_wrappers.rs
+++ b/src/ui_bevy/ui_ext/style_wrappers.rs
@@ -1328,11 +1328,10 @@ impl StaticAttribute for DisplayControl
 /// Like [`Val`] but also accepts additional values for grid layouts.
 ///
 /// Can be converted to a [`GridTrack`] for use in [`Node`].
-#[derive(Clone, Copy, Default, Debug, Reflect, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, Reflect, PartialEq, Serialize, Deserialize)]
 #[reflect(Default, PartialEq, Debug)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
 pub enum GridVal

--- a/tests/test/cob/helpers/serde_types.rs
+++ b/tests/test/cob/helpers/serde_types.rs
@@ -340,6 +340,7 @@ pub struct BuiltinCollection
     pub vmin: Val,
     pub vmax: Val,
     pub color: Color,
+    pub fr: GridVal,
 }
 
 impl Instruction for BuiltinCollection

--- a/tests/test/cob/serde.rs
+++ b/tests/test/cob/serde.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use bevy::prelude::*;
+use bevy_cobweb_ui::ui_bevy::GridVal;
 
 use super::helpers::*;
 
@@ -314,7 +315,7 @@ fn aggregate_struct()
             float: 1.0,
             boolean: true,
             string: String::from("hi"),
-            vec: vec![PlainStruct{boolean: true}, PlainStruct{boolean: false}],
+            vec: vec![PlainStruct { boolean: true }, PlainStruct { boolean: false }],
             map,
             s_struct: UnitStruct,
             s_enum: EnumStruct::B(UnitStruct),
@@ -463,8 +464,8 @@ fn builtins()
     let a = prepare_test_app();
     test_equivalence(
         a.world(),
-        "BuiltinCollection{auto_val:auto px:0px percent:1% vw:1vw vh:1vh vmin:1vmin vmax:1vmax color:#FFFFFF}",
-        "{auto_val:auto px:0px percent:1% vw:1vw vh:1vh vmin:1vmin vmax:1vmax color:#FFFFFF}",
+        "BuiltinCollection{auto_val:auto px:0px percent:1% vw:1vw vh:1vh vmin:1vmin vmax:1vmax fr:1fr color:#FFFFFF}",
+        "{auto_val:auto px:0px percent:1% vw:1vw vh:1vh vmin:1vmin vmax:1vmax fr:1fr color:#FFFFFF}",
         BuiltinCollection {
             auto_val: Val::Auto,
             px: Val::Px(0.0),
@@ -473,13 +474,14 @@ fn builtins()
             vh: Val::Vh(1.0),
             vmin: Val::VMin(1.0),
             vmax: Val::VMax(1.0),
+            fr:GridVal::Fr(1.0),
             color: Color::Srgba(Default::default()),
         },
     );
     test_equivalence(
         a.world(),
-        "BuiltinCollection{auto_val:auto px:1.1px percent:1.1% vw:1.1vw vh:1.1vh vmin:1.1vmin vmax:1.1vmax color:#FF0000}",
-        "{auto_val:auto px:1.1px percent:1.1% vw:1.1vw vh:1.1vh vmin:1.1vmin vmax:1.1vmax color:#FF0000}",
+        "BuiltinCollection{auto_val:auto px:1.1px percent:1.1% vw:1.1vw vh:1.1vh vmin:1.1vmin vmax:1.1vmax fr:1.1fr color:#FF0000}",
+        "{auto_val:auto px:1.1px percent:1.1% vw:1.1vw vh:1.1vh vmin:1.1vmin vmax:1.1vmax fr:1.1fr color:#FF0000}",
         BuiltinCollection {
             auto_val: Val::Auto,
             px: Val::Px(1.1),
@@ -488,6 +490,7 @@ fn builtins()
             vh: Val::Vh(1.1),
             vmin: Val::VMin(1.1),
             vmax: Val::VMax(1.1),
+            fr:GridVal::Fr(1.1),
             color: Color::Srgba(Srgba::RED),
         },
     );


### PR DESCRIPTION
Grid support for  
grid-template-rows
grid-template-columns.

I created a new Enum called `gridVal`  for serialisation, that can read in data in a standard cob format.

`GridVal` is converted into the bevy data structure `GridTrack` We cannot use `GridTrack` directly in the same manner as `Val` since `GridTrack` is not an enum.

Grids can be used in `cob` files by using the `GridNode` syntax, `GridNode` is a mix of `AbsoluteNode` and `FlexNode`.

`DisplayControl` may need to be rewritten.

I also just realised I need to write tests as well.