### PR TITLE
Use new feature in cobweb crate to sync with bevy change tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,12 @@ rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 # Default features.
 default = ["colors", "widgets"]
 
+# Corresponds to `bevy/track_change_detection`
+track_change_detection = [
+  "bevy/track_change_detection",
+  "bevy_cobweb/track_change_detection",
+]
+
 # Enables built-in colors.
 colors = []
 


### PR DESCRIPTION
Depends on the fix in https://github.com/UkoeHB/bevy_cobweb/pull/5.

Once that PR is merged, you will need to bump the version number of that crate so that this crate can reliably use the newly added feature.